### PR TITLE
Fix presets being set and state restore

### DIFF
--- a/RNBO_JuceAudioProcessor.cpp
+++ b/RNBO_JuceAudioProcessor.cpp
@@ -243,6 +243,9 @@ void JuceAudioProcessor::handleParameterEvent(const ParameterEvent& event)
 			param->setValueNotifyingHost((float)normalizedValue);
 			param->endChangeGesture();
 		}
+		else {
+			param->setValue((float)normalizedValue);
+		}
 	}
 }
 


### PR DESCRIPTION
This PR tries to fix an issue where preset changes and state restore are not working with RNBO v1.2.0 due to a fix to 'notifying' parameters, that will make it so that certain parts of RNBO state aren't updated with the new parameter values on those two scenarios. I need to test further to see if this will address the issue and am not familiar with the bigger picture of this project to tell if it'd be okay or problematic for `rnbo.getParameterValue` to return a different result than the state objects or parameter values.

I'm not sure if preset handling will be totally correct with this change since the parameters would not be notifying the hosts depending on how they are called.

`RNBO::JuceAudioProcessor::setCurrentProgram` does not set `_isSettingPresetAsync` as far as I can tell. Therefore parameter change events for `setCurrentProgram` and `setStateInformation` are being dropped.

This change makes it so that these events aren't dropped but still skips notifying hosts. Perhaps a more robust change could be to set a flag while the `setCurrentProgram` and `setStateInformation` run and handle them in the same manner as "_isSettingPresetAsync".

I might be totally wrong about the whole thing as well!

This fixes the test suite referenced in #2.

Closes #2.

- https://github.com/Cycling74/rnbo.adapter.juce/blob/dd233609adc495828fa9efcf756ab2a155a3bd1d/RNBO_JuceAudioProcessor.cpp#L412-L421

All the best, happy patching