### PR TITLE
Xnor/more notification

### DIFF
--- a/RNBO_JuceAudioProcessor.cpp
+++ b/RNBO_JuceAudioProcessor.cpp
@@ -235,10 +235,7 @@ void JuceAudioProcessor::handleParameterEvent(const ParameterEvent& event)
 		// we need to normalize the parameter value
 		ParameterValue normalizedValue = _rnboObject.convertToNormalizedParameterValue(event.getIndex(), event.getValue());
 		const auto param = getParameters()[it->second];
-		if (_isInStartup || _isSettingPresetAsync) {
-			param->setValue((float)normalizedValue);
-		}
-		else if (_notifyingParameters.count(event.getIndex()) != 0) {
+		if (_isInStartup || _isSettingPresetAsync || _notifyingParameters.count(event.getIndex()) != 0) {
 			param->beginChangeGesture();
 			param->setValueNotifyingHost((float)normalizedValue);
 			param->endChangeGesture();

--- a/RNBO_JuceAudioProcessor.cpp
+++ b/RNBO_JuceAudioProcessor.cpp
@@ -110,7 +110,6 @@ JuceAudioProcessor::JuceAudioProcessor(
 #endif
 	)
 	, Thread("fileLoadAndDealloc")
-	, _syncEventHandler(*this)
 	, _currentPresetIdx(-1)
 {
 	_dataRefCleanupQueue = make_unique<moodycamel::ReaderWriterQueue<char *, 32>>(static_cast<size_t>(32));
@@ -161,8 +160,6 @@ JuceAudioProcessor::JuceAudioProcessor(
 			}
 		}
 	}
-
-	_syncParamInterface = _rnboObject.createParameterInterface(ParameterEventInterface::NotThreadSafe, &_syncEventHandler);
 
 	//Read presets
 	try  {
@@ -235,10 +232,15 @@ void JuceAudioProcessor::handleParameterEvent(const ParameterEvent& event)
 		// we need to normalize the parameter value
 		ParameterValue normalizedValue = _rnboObject.convertToNormalizedParameterValue(event.getIndex(), event.getValue());
 		const auto param = getParameters()[it->second];
-		if (_isInStartup || _isSettingPresetAsync || _notifyingParameters.count(event.getIndex()) != 0) {
+		if (_isSettingPresetAsync || _notifyingParameters.count(event.getIndex()) != 0) {
+			//using "internal" method to simply notify listeners
+#if RNBO_JUCE_PARAM_EVENT_NOTIFY_ONLY
+			param->sendValueChangedMessageToListeners((float)normalizedValue);
+#else
 			param->beginChangeGesture();
 			param->setValueNotifyingHost((float)normalizedValue);
 			param->endChangeGesture();
+#endif
 		}
 	}
 }
@@ -571,31 +573,13 @@ void JuceAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
 {
 	String rnboPresetStr = String::createStringFromData (data, sizeInBytes);
 	auto rnboPreset = RNBO::convertJSONToPreset(rnboPresetStr.toStdString());
-	_rnboObject.setPresetSync(std::move(rnboPreset));
+	_rnboObject.setPreset(std::move(rnboPreset));
 }
 
 void JuceAudioProcessor::eventsAvailable()
 {
 	this->triggerAsyncUpdate();
 }
-
-void JuceAudioProcessor::SyncEventHandler::handleParameterEvent(const RNBO::ParameterEvent& event)
-{
-	if (_isSettingPresetSync) {
-		_owner.handleParameterEvent(event);
-	}
-}
-
-void JuceAudioProcessor::SyncEventHandler::handlePresetEvent(const PresetEvent& event)
-{
-	if (event.getType() == PresetEvent::SettingBegin) {
-		_isSettingPresetSync = true;
-	}
-	else if (event.getType() == PresetEvent::SettingEnd) {
-		_isSettingPresetSync = false;
-	}
-}
-
 
 JuceAudioParameterFactory::JuceAudioParameterFactory(
 		const nlohmann::json& patcherdesc

--- a/RNBO_JuceAudioProcessor.cpp
+++ b/RNBO_JuceAudioProcessor.cpp
@@ -596,8 +596,6 @@ void JuceAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
 	auto rnboPreset = RNBO::convertJSONToPreset(rnboPresetStr.toStdString());
 	_rnboObject.setPresetSync(std::move(rnboPreset));
 
-	drainEvents();
-
 	// notify changes
 	for (auto& kv: _rnboParamIndexToJuceParamIndex) {
 		auto index = kv.first;

--- a/RNBO_JuceAudioProcessor.h
+++ b/RNBO_JuceAudioProcessor.h
@@ -256,10 +256,7 @@ namespace RNBO {
 		void setValue (float newValue) override
 		{
 			jassert(newValue >= 0 && newValue <= 1.);	// should be getting normalized values
-			float oldValue = getValue();
-			if (newValue != oldValue) {
-				_rnboObject.setParameterValueNormalized(_index, newValue);
-			}
+			_rnboObject.setParameterValueNormalized(_index, newValue);
 		}
 
 		float getDefaultValue() const override

--- a/RNBO_JuceAudioProcessor.h
+++ b/RNBO_JuceAudioProcessor.h
@@ -53,15 +53,15 @@ namespace RNBO {
 			virtual ~JuceAudioParameterFactory() = default;
 
 			//entrypoint, may return null
-			juce::AudioProcessorParameter* create(RNBO::CoreObject& rnboObject, ParameterIndex index);
+			juce::AudioProcessorParameter* create(RNBO::CoreObject& rnboObject, RNBO::ParameterInterface * parameterInterface, ParameterIndex index);
 
 		protected:
 			//overrideable entrypoint
-			virtual juce::AudioProcessorParameter* create(RNBO::CoreObject& rnboObject, ParameterIndex index, const ParameterInfo& info, int versionHint, const nlohmann::json& meta);
+			virtual juce::AudioProcessorParameter* create(RNBO::CoreObject& rnboObject, RNBO::ParameterInterface * parameterInterface, ParameterIndex index, const ParameterInfo& info, int versionHint, const nlohmann::json& meta);
 
 			//called by create if appropriate
-			virtual juce::AudioProcessorParameter* createEnum(RNBO::CoreObject& rnboObject, ParameterIndex index, const ParameterInfo& info, int versionHint, const nlohmann::json& meta);
-			virtual juce::AudioProcessorParameter* createFloat(RNBO::CoreObject& rnboObject, ParameterIndex index, const ParameterInfo& info, int versionHint, const nlohmann::json& meta);
+			virtual juce::AudioProcessorParameter* createEnum(RNBO::CoreObject& rnboObject, RNBO::ParameterInterface * parameterInterface, ParameterIndex index, const ParameterInfo& info, int versionHint, const nlohmann::json& meta);
+			virtual juce::AudioProcessorParameter* createFloat(RNBO::CoreObject& rnboObject, RNBO::ParameterInterface * parameterInterface, ParameterIndex index, const ParameterInfo& info, int versionHint, const nlohmann::json& meta);
 
 			bool automate(const nlohmann::json& meta);
 
@@ -152,6 +152,8 @@ namespace RNBO {
 		//==============================================================================
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (JuceAudioProcessor)
 
+		RNBO::ParameterEventInterfaceUniquePtr _parameterInterface;
+
 		RNBO::MidiEventList						_midiInput;
 		RNBO::MidiEventList						_midiOutput;
 		std::unique_ptr<RNBO::PresetList>	_presetList;
@@ -182,6 +184,7 @@ namespace RNBO {
 
 		std::unique_ptr<moodycamel::ReaderWriterQueue<char *, 32>> _dataRefCleanupQueue;
 		std::unique_ptr<moodycamel::ReaderWriterQueue<std::pair<juce::String, juce::File>, 32>> _dataRefLoadQueue;
+
 	};
 
 	class DataRefUpdatedMessage : public juce::Message {
@@ -200,14 +203,14 @@ namespace RNBO {
 		using String = juce::String;
 	public:
 
-		FloatParameter (ParameterIndex index, const ParameterInfo& info, CoreObject& rnboObject, int versionHint = 0, bool automatable = true)
+		FloatParameter (ParameterIndex index, const ParameterInfo& info, CoreObject& rnboObject, RNBO::ParameterInterface * parameterInterface, int versionHint = 0, bool automatable = true)
 		:
 			juce::RangedAudioParameter(
 					paramIdForRNBOParam(rnboObject, index, versionHint),
 					String(rnboObject.getParameterName(index))
 			)
 		, _index(index)
-		, _rnboObject(rnboObject)
+		, _parameterInterface(parameterInterface)
 		, _automatable(automatable)
 		{
 
@@ -217,10 +220,10 @@ namespace RNBO {
 
 			_name = String(info.displayName);
 			if (_name.isEmpty()) {
-				_name = String(_rnboObject.getParameterId(_index));
+				_name = String(_parameterInterface->getParameterId(_index));
 			}
 
-			_defaultValue = static_cast<float>(_rnboObject.convertToNormalizedParameterValue(_index, info.initialValue));
+			_defaultValue = static_cast<float>(_parameterInterface->convertToNormalizedParameterValue(_index, info.initialValue));
 
 			auto min = static_cast<float>(info.min);
 			auto max = static_cast<float>(info.max);
@@ -234,7 +237,8 @@ namespace RNBO {
 		float getValue() const override
 		{
 			// getValue wants the value between 0 and 1
-			float normalizedValue = (float)_rnboObject.getParameterNormalized(_index);
+			float normalizedValue = (float)_parameterInterface->getParameterNormalized(_index);
+			// std::cout << "getValue " << normalizedValue << std::endl;
 			return normalizedValue;
 		}
 
@@ -243,11 +247,11 @@ namespace RNBO {
 			jassert(newValue >= 0 && newValue <= 1.);	// should be getting normalized values
 #if RNBO_JUCE_PARAM_EVENT_NOTIFY_ONLY
 			//no need to check old value if we don't feed back
-			_rnboObject.setParameterValueNormalized(_index, newValue);
+			_parameterInterface->setParameterValueNormalized(_index, newValue);
 #else
 			float oldValue = getValue();
 			if (newValue != oldValue) {
-				_rnboObject.setParameterValueNormalized(_index, newValue);
+				_parameterInterface->setParameterValueNormalized(_index, newValue);
 			}
 #endif
 		}
@@ -259,7 +263,7 @@ namespace RNBO {
 
 		String getParameterID() const override
 		{
-			return String(_rnboObject.getParameterId(_index));
+			return String(_parameterInterface->getParameterId(_index));
 		}
 
 		String getName (int maximumStringLength) const override
@@ -284,7 +288,7 @@ namespace RNBO {
 		String getText (float value, int maximumStringLength) const override
 		{
 			// we want to print the normalized value
-			float displayValue = (float)_rnboObject.convertFromNormalizedParameterValue(_index, value);
+			float displayValue = (float)_parameterInterface->convertFromNormalizedParameterValue(_index, value);
 			return AudioProcessorParameter::getText(displayValue, maximumStringLength);
 		}
 
@@ -297,7 +301,7 @@ namespace RNBO {
 
 	protected:
 		ParameterIndex			_index;
-		CoreObject&				_rnboObject;
+		RNBO::ParameterInterface * _parameterInterface;
 		String _unitName;
 		String _name;
 		float _defaultValue;
@@ -310,8 +314,8 @@ namespace RNBO {
 		using String = juce::String;
 	public:
 
-		EnumParameter (ParameterIndex index, const ParameterInfo& info, CoreObject& rnboObject, int versionHint = 0, bool automatable = true)
-		: FloatParameter(index, info, rnboObject, versionHint, automatable)
+		EnumParameter (ParameterIndex index, const ParameterInfo& info, CoreObject& rnboObject, RNBO::ParameterInterface * parameterInterface, int versionHint = 0, bool automatable = true)
+		: FloatParameter(index, info, rnboObject, parameterInterface, versionHint, automatable)
 		{
 			for (Index i = 0; i < static_cast<Index>(info.steps); i++) {
 				_enumValues.push_back(info.enumValues[i]);
@@ -321,7 +325,7 @@ namespace RNBO {
 		String getText (float value, int maximumStringLength) const override
 		{
 			// we want to print the normalized value
-			long displayValue = (long)_rnboObject.convertFromNormalizedParameterValue(_index, value);
+			long displayValue = (long)_parameterInterface->convertFromNormalizedParameterValue(_index, value);
 			String v;
 			if (displayValue >= 0 && static_cast<Index>(displayValue) < _enumValues.size()) {
 				v = _enumValues[static_cast<Index>(displayValue)];

--- a/RNBO_JuceAudioProcessor.h
+++ b/RNBO_JuceAudioProcessor.h
@@ -155,6 +155,7 @@ namespace RNBO {
 		RNBO::MidiEventList						_midiInput;
 		RNBO::MidiEventList						_midiOutput;
 		std::unique_ptr<RNBO::PresetList>	_presetList;
+		RNBO::ConstPresetPtr _initialPreset;
 		int										_currentPresetIdx;
 		bool									_isInStartup = false;
 		bool									_isSettingPresetAsync = false;

--- a/RNBO_JuceAudioProcessor.h
+++ b/RNBO_JuceAudioProcessor.h
@@ -240,9 +240,9 @@ namespace RNBO {
 		void setValue (float newValue) override
 		{
 			jassert(newValue >= 0 && newValue <= 1.);	// should be getting normalized values
-			#if RNBO_JUCE_PARAM_EVENT_NOTIFY_ONLY
-				//no need to check old value if we don't feed back
-				_rnboObject.setParameterValueNormalized(_index, newValue);
+#if RNBO_JUCE_PARAM_EVENT_NOTIFY_ONLY
+			//no need to check old value if we don't feed back
+			_rnboObject.setParameterValueNormalized(_index, newValue);
 #else
 			float oldValue = getValue();
 			if (newValue != oldValue) {


### PR DESCRIPTION
RE https://app.assembla.com/spaces/max/tickets/realtime_cardwall?tickets_report_id=milestone:13092026&ticket=18921

I don't think we need this extra parameter/event interface.

A key element here is that I changed the state restore to use the async method so it happens in the correct order relative to startup events and any parameter events that came before it.

finally, now the output parameter events simply notify the host that a value has changed instead of actually setting the value and filtering out feedback (removed the filtering)