### PR TITLE
JuceAudioProcessor, using std::shared_ptr for _dataRefCleanupQueue

### DIFF
--- a/RNBO_JuceAudioProcessor.cpp
+++ b/RNBO_JuceAudioProcessor.cpp
@@ -114,7 +114,7 @@ JuceAudioProcessor::JuceAudioProcessor(
 	, Thread("fileLoadAndDealloc")
 	, _currentPresetIdx(0)
 {
-	_dataRefCleanupQueue = make_unique<moodycamel::ReaderWriterQueue<char *, 32>>(static_cast<size_t>(32));
+	_dataRefCleanupQueue = std::make_shared<moodycamel::ReaderWriterQueue<char *, 32>>(static_cast<size_t>(32));
 	_dataRefLoadQueue = make_unique<moodycamel::ReaderWriterQueue<std::pair<juce::String, juce::File>, 32>>(static_cast<size_t>(32));
 
 	_formatManager.registerBasicFormats();
@@ -343,9 +343,10 @@ void JuceAudioProcessor::loadDataRef(const juce::String refName, const juce::Str
 							reinterpret_cast<char *>(data),
 							samps * sizeof(float),
 							bufferType,
-							[this](RNBO::ExternalDataId, char* d) {
+							[cleanUpQueue = _dataRefCleanupQueue](RNBO::ExternalDataId, char* d) {
 								//hold onto shared_ptr until rnbo stops using it
-								_dataRefCleanupQueue->enqueue(d);
+								if (cleanUpQueue)
+									cleanUpQueue->enqueue(d);
 							}
 					);
 					_loadedDataRefs.insert({refName, fileName});

--- a/RNBO_JuceAudioProcessor.h
+++ b/RNBO_JuceAudioProcessor.h
@@ -178,7 +178,7 @@ namespace RNBO {
     juce::AudioFormatManager _formatManager;
 		juce::MessageListener * _dataRefListener = nullptr;
 
-		std::unique_ptr<moodycamel::ReaderWriterQueue<char *, 32>> _dataRefCleanupQueue;
+		std::shared_ptr<moodycamel::ReaderWriterQueue<char *, 32>> _dataRefCleanupQueue;
 		std::unique_ptr<moodycamel::ReaderWriterQueue<std::pair<juce::String, juce::File>, 32>> _dataRefLoadQueue;
 	};
 


### PR DESCRIPTION
This fixes a problem with deallocation order for objects with data refs