### PR TITLE
check if thread is still running before queuing for deletion

### DIFF
--- a/RNBO_JuceAudioProcessor.cpp
+++ b/RNBO_JuceAudioProcessor.cpp
@@ -344,8 +344,12 @@ void JuceAudioProcessor::loadDataRef(const juce::String refName, const juce::Str
 							samps * sizeof(float),
 							bufferType,
 							[this](RNBO::ExternalDataId, char* d) {
-								//hold onto shared_ptr until rnbo stops using it
-								_dataRefCleanupQueue->enqueue(d);
+								if (isThreadRunning()) {
+									_dataRefCleanupQueue->enqueue(d);
+								}
+								else {
+									delete [] d;
+								}
 							}
 					);
 					_loadedDataRefs.insert({refName, fileName});

--- a/RNBO_JuceAudioProcessor.h
+++ b/RNBO_JuceAudioProcessor.h
@@ -71,10 +71,10 @@ namespace RNBO {
 	 */
 	class JuceAudioProcessor :
 		public RNBO::EventHandler,
+		private juce::Thread,
 		public CoreObjectHolder,
 		public juce::AudioProcessor,
-		public juce::AsyncUpdater,
-		private juce::Thread
+		public juce::AsyncUpdater
 	{
 		using String = juce::String;
 	public:


### PR DESCRIPTION
if not, it is safe to delete right away

also re-order inheritance to make sure Thread members are not destroyed first