### PR TITLE
reset param interface and cancel any pending updates on destruction

### DIFF
--- a/RNBO_JuceAudioProcessorEditor.cpp
+++ b/RNBO_JuceAudioProcessorEditor.cpp
@@ -285,6 +285,8 @@ RNBOAudioProcessorEditor::RNBOAudioProcessorEditor(JuceAudioProcessor* const p, 
 
 RNBOAudioProcessorEditor::~RNBOAudioProcessorEditor()
 {
+	_parameterInterface.reset();
+	cancelPendingUpdate();
 }
 
 void RNBOAudioProcessorEditor::paint (Graphics& g)


### PR DESCRIPTION
no need for any draining at that moment, the queue is destroyed